### PR TITLE
Add unit tests for KubeconformException and GetCommand methods

### DIFF
--- a/Devantler.KubeconformCLI.Tests/KubeconformExceptionTests.cs
+++ b/Devantler.KubeconformCLI.Tests/KubeconformExceptionTests.cs
@@ -1,0 +1,55 @@
+namespace Devantler.KubeconformCLI.Tests;
+
+/// <summary>
+/// Tests for the <see cref="KubeconformException"/> class.
+/// </summary>
+public class KubeconformExceptionTests
+{
+  /// <summary>
+  /// Tests the default constructor.
+  /// </summary>
+  [Fact]
+  public void Constructor_GivenNothing_CallsDefaultConstructor()
+  {
+    // Act
+    var exception = new KubeconformException();
+
+    // Assert
+    Assert.NotNull(exception);
+  }
+
+  /// <summary>
+  /// Tests the constructor with a message.
+  /// </summary>
+  [Fact]
+  public void Constructor_GivenMessage_SetsMessageProperty()
+  {
+    // Arrange
+    string message = "Test message";
+
+    // Act
+    var exception = new KubeconformException(message);
+
+    // Assert
+    Assert.Equal(message, exception.Message);
+  }
+
+  /// <summary>
+  /// Tests the constructor with a message and inner exception.
+  /// </summary>
+  [Fact]
+  public void Constructor_GivenMessageAndInnerException_SetsMessageAndInnerExceptionProperties()
+  {
+    // Arrange
+    string message = "Test message";
+    var innerException = new NotImplementedException();
+
+    // Act
+    var exception = new KubeconformException(message, innerException);
+
+    // Assert
+    Assert.Equal(message, exception.Message);
+    Assert.Equal(innerException, exception.InnerException);
+  }
+}
+

--- a/Devantler.KubeconformCLI.Tests/KubeconformTests/GetCommandTests.cs
+++ b/Devantler.KubeconformCLI.Tests/KubeconformTests/GetCommandTests.cs
@@ -1,9 +1,46 @@
+using System.Runtime.InteropServices;
+
 namespace Devantler.KubeconformCLI.Tests.KubeconformTests;
 
 /// <summary>
-/// Tests for the GetCommand method.
+/// Tests for the <see cref="Kubeconform.GetCommand(PlatformID?, Architecture?, string?)"/> method.
 /// </summary>
 public class GetCommandTests
 {
+  /// <summary>
+  /// Test to verify that the command returns the correct binary for MacOS on x64 architecture.
+  /// </summary>
+  [Theory]
+  [InlineData(PlatformID.Unix, Architecture.X64, "osx-x64", "kubeconform-osx-x64")]
+  [InlineData(PlatformID.Unix, Architecture.Arm64, "osx-arm64", "kubeconform-osx-arm64")]
+  [InlineData(PlatformID.Unix, Architecture.X64, "linux-x64", "kubeconform-linux-x64")]
+  [InlineData(PlatformID.Unix, Architecture.Arm64, "linux-arm64", "kubeconform-linux-arm64")]
+  [InlineData(PlatformID.Win32NT, Architecture.X64, "win-x64", "kubeconform-win-x64.exe")]
+  [InlineData(PlatformID.Win32NT, Architecture.X64, "win-arm64", "kubeconform-win-arm64.exe")]
+  public void GetCommand_ShouldReturnOSXx64Binary(PlatformID platformID, Architecture architecture, string runtimeIdentifier, string expectedBinary)
+  {
+    // Act
+    string actualBinary = Path.GetFileName(Kubeconform.GetCommand(platformID, architecture, runtimeIdentifier).TargetFilePath);
 
+    // Assert
+    Assert.Equal(expectedBinary, actualBinary);
+  }
+
+  /// <summary>
+  /// Test to verify that the command returns a <see cref="PlatformNotSupportedException"/> when the platform is not supported.
+  /// </summary>
+  [Fact]
+  public void GetCommand_GivenInvaldiPlatform_ShouldThrowPlatformNotSupportedException()
+  {
+    // Arrange
+    var platformID = PlatformID.Other;
+    var architecture = Architecture.Wasm;
+    string runtimeIdentifier = "wasm";
+
+    // Act
+    void Act() => Kubeconform.GetCommand(platformID, architecture, runtimeIdentifier);
+
+    // Assert
+    _ = Assert.Throws<PlatformNotSupportedException>(Act);
+  }
 }


### PR DESCRIPTION
Introduce unit tests for the `KubeconformException` class and the `GetCommand` method, ensuring proper functionality and error handling across various scenarios.