### PR TITLE
Simplify KubeconformException message

### DIFF
--- a/Devantler.KubeconformCLI.Tests/KubeconformTests/RunAsyncTests.cs
+++ b/Devantler.KubeconformCLI.Tests/KubeconformTests/RunAsyncTests.cs
@@ -15,7 +15,7 @@ public class RunAsyncTests
     // Arrange
     string[] kubeconformFlags = ["-skip=Secret"];
     string[] kubeconformConfig = ["-strict", "-ignore-missing-schemas", "-schema-location", "default", "-schema-location", "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json", "-verbose"];
-    string assetsDirectoryPath = Path.Combine(AppContext.BaseDirectory, "assets");
+    string assetsDirectoryPath = Path.Combine(AppContext.BaseDirectory, "assets", "k8s");
     string[] filesInAssetsDirectory = Directory.GetFiles(assetsDirectoryPath, "*.yaml", SearchOption.AllDirectories);
 
     // Act
@@ -45,7 +45,7 @@ public class RunAsyncTests
   public async Task RunAsync_WithDefaults_ShouldRunSuccessfully()
   {
     // Arrange
-    string assetsDirectoryPath = Path.Combine(AppContext.BaseDirectory, "assets");
+    string assetsDirectoryPath = Path.Combine(AppContext.BaseDirectory, "assets", "k8s");
     string[] filesInAssetsDirectory = Directory.GetFiles(assetsDirectoryPath, "*.yaml", SearchOption.AllDirectories);
 
     // Act
@@ -65,5 +65,36 @@ public class RunAsyncTests
 
     // Assert
     Assert.Empty(exceptions);
+  }
+
+
+  /// <summary>
+  /// Tests the RunAsync method with defaults.
+  /// </summary>
+  /// <returns></returns>
+  [Fact]
+  public async Task RunAsync_WithDefaultsAndSchemaIssue_ShouldFailWithException()
+  {
+    // Arrange
+    string assetsDirectoryPath = Path.Combine(AppContext.BaseDirectory, "assets", "k8s-schema-issue");
+    string[] filesInAssetsDirectory = Directory.GetFiles(assetsDirectoryPath, "*.yaml", SearchOption.AllDirectories);
+
+    // Act
+    var exceptions = new List<Exception>();
+
+    foreach (string file in filesInAssetsDirectory)
+    {
+      try
+      {
+        await Kubeconform.RunAsync(file, cancellationToken: CancellationToken.None);
+      }
+      catch (KubeconformException ex)
+      {
+        exceptions.Add(ex);
+      }
+    }
+
+    // Assert
+    Assert.NotEmpty(exceptions);
   }
 }

--- a/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/apps/kustomization.yaml
+++ b/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/apps/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/clusters/ksail-default/flux-system/apps.yaml
+++ b/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/clusters/ksail-default/flux-system/apps.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 60m
+  retryInterval: 2m
+  timeout: 3m
+  dependsOn: []
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: apps
+  prune: true
+  wait: 1

--- a/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/clusters/ksail-default/flux-system/infrastructure-controllers.yaml
+++ b/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/clusters/ksail-default/flux-system/infrastructure-controllers.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infrastructure-controllers
+  namespace: flux-system
+spec:
+  interval: 60m
+  retryInterval: 2m
+  timeout: 3m
+  dependsOn:
+  - name: infrastructure
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: infrastructure/controllers
+  prune: true
+  wait: true

--- a/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/clusters/ksail-default/flux-system/infrastructure.yaml
+++ b/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/clusters/ksail-default/flux-system/infrastructure.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infrastructure
+  namespace: flux-system
+spec:
+  interval: 60m
+  retryInterval: 2m
+  timeout: 3m
+  dependsOn:
+  - name: apps
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: infrastructure
+  prune: true
+  wait: true

--- a/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/clusters/ksail-default/flux-system/kustomization.yaml
+++ b/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/clusters/ksail-default/flux-system/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- apps.yaml
+- infrastructure.yaml
+- infrastructure-controllers.yaml

--- a/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/infrastructure/controllers/kustomization.yaml
+++ b/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/infrastructure/controllers/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/infrastructure/kustomization.yaml
+++ b/Devantler.KubeconformCLI.Tests/assets/k8s-schema-issue/infrastructure/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/Devantler.KubeconformCLI/Kubeconform.cs
+++ b/Devantler.KubeconformCLI/Kubeconform.cs
@@ -52,6 +52,6 @@ public static class Kubeconform
     var cmd = Command.WithArguments(arguments);
     var (exitCode, result) = await CLI.RunAsync(cmd, silent: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
-      throw new KubeconformException($"Kubeconform failed with exit code {exitCode} and error: {result}");
+      throw new KubeconformException($"{result}");
   }
 }


### PR DESCRIPTION
Streamline the error message in KubeconformException to display only the error result, enhancing clarity.