### PR TITLE
Refactor variable name from 'message' to 'output' in RunAsync

### DIFF
--- a/Devantler.KubeconformCLI.Tests/KubeconformTests/RunAsyncTests.cs
+++ b/Devantler.KubeconformCLI.Tests/KubeconformTests/RunAsyncTests.cs
@@ -13,10 +13,10 @@ public class RunAsyncTests
   public async Task RunAsync_Version_ReturnsVersion()
   {
     // Act
-    var (exitCode, message) = await Kubeconform.RunAsync(["-v"]);
+    var (exitCode, output) = await Kubeconform.RunAsync(["-v"]);
 
     // Assert
     Assert.Equal(0, exitCode);
-    Assert.Matches(@"^v\d+\.\d+\.\d+$", message.Trim());
+    Assert.Matches(@"^v\d+\.\d+\.\d+$", output.Trim());
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ You can execute the Kubeconform CLI commands using the `Kubeconform` class.
 ```csharp
 using Devantler.KubeconformCLI;
 
-var (exitCode, message) = await Kubeconform.RunAsync(["arg1", "arg2"]);
+var (exitCode, output) = await Kubeconform.RunAsync(["arg1", "arg2"]);
 ```


### PR DESCRIPTION
Update the variable name in the RunAsync method to improve clarity and consistency in the code.